### PR TITLE
list: --commit COMMIT_ID filtering

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -20,6 +20,7 @@ type filterFlags struct {
 	FilterRunner  []string          `short:"r" long:"runner" description:"Select only builds for the given runner"`
 	FilterJob     []string          `short:"j" long:"job" description:"Select only builds for the given job"`
 	FilterBuild   []string          `short:"b" long:"build" description:"Select only builds with buildnumber"`
+	FilterCommit  string            `short:"m" long:"commit" description:"Select only build with certain commit"`
 	OnlyAllFailed bool              `long:"all-failed" description:"Select only failed builds"`
 	OnlyFailing   bool              `long:"failing" description:"Select only currently failing builds"`
 }

--- a/render.go
+++ b/render.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ohmu/tjob/pipeline"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -50,6 +51,8 @@ func (node *resultFilterer) Run() error {
 	for cur := range node.Input {
 		var sendVal *JobStatus
 		switch {
+		case node.flags.FilterCommit != "" &&
+			(cur.Status == nil || !strings.HasPrefix(cur.Status.CommitID(), node.flags.FilterCommit)):
 		case node.display.SinceDuration != 0 &&
 			!filterByStartedSince(node.display, cur.Status):
 		case node.flags.OnlyAllFailed && (cur.Status == nil ||


### PR DESCRIPTION
Add filtering by commit id. I find that useful when triggering many builds from the same branch and then would only like to get build results for the current version of the branch when I have tagged the builds with branch name:

```
tjob list -m `git rev-parse --short HEAD` -t `git rev-parse --abbrev-ref HEAD`
```
